### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/utils/index.ts
+++ b/utils/index.ts
@@ -13,8 +13,6 @@ export async function fetchCars(filters: FilterProps) {
 		},
 	};
 
-	// console.log(process.env.RAPID_API_KEY); // Removed: avoid logging sensitive data
-
 	try {
 		const response = await fetch(url, options);
 

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -13,7 +13,7 @@ export async function fetchCars(filters: FilterProps) {
 		},
 	};
 
-	console.log(process.env.RAPID_API_KEY);
+	// console.log(process.env.RAPID_API_KEY); // Removed: avoid logging sensitive data
 
 	try {
 		const response = await fetch(url, options);


### PR DESCRIPTION
Potential fix for [https://github.com/0s1n/car_showcase/security/code-scanning/1](https://github.com/0s1n/car_showcase/security/code-scanning/1)

To fix the problem, we should remove or redact the log statement that outputs the value of `process.env.RAPID_API_KEY`. Sensitive environment variables such as API keys must not be logged in clear text regardless of environment. If debugging is absolutely needed, log a message indicating a key is present or check for its definition, but do not print its value. The change will be made inside utils/index.ts, specifically by removing or altering line 16.

No additional imports, methods, or definitions are needed—simply remove or modify the log statement.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
